### PR TITLE
Formatting consistency, readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ And constructed with the following guidelines:
 
 For more information on SemVer, please visit http://semver.org.
 
+##Workflow
+
+XboxLiveAPI will be developed using the [GitHub Workflow](http://scottchacon.com/2011/08/31/github-flow.html) as much as possible. All pull requests
+must be against the `*-wip` branches. Commits will be made to `*.0.x-dev` branches before being pushed to `master`.
+
 ##Author
 - Email: me@jasonclemons.me
 - Twitter: http://twitter.com/jasonclemons
@@ -44,7 +49,7 @@ For more information on SemVer, please visit http://semver.org.
 ### Profile Model
 
 ```php
-$data = $api->fetch_profile($gamertag, $region);`
+$data = $api->fetch_profile($gamertag, $region);
 ```
 
 ### Games Model

--- a/source/2.0/achievements.php
+++ b/source/2.0/achievements.php
@@ -11,8 +11,8 @@
  * @license     http://opensource.org/licenses/mit-license.php The MIT License *
  *******************************************************************************/
 
-include("../includes/bootloader.php");
-include("includes/kernel.php");
+include('../includes/bootloader.php');
+include('includes/kernel.php');
 $api->output_headers();
 
 $gamertag = (isset($_GET['gamertag']) && !empty($_GET['gamertag'])) ? trim($_GET['gamertag']) : null;

--- a/source/2.0/friends.php
+++ b/source/2.0/friends.php
@@ -11,8 +11,8 @@
  * @license     http://opensource.org/licenses/mit-license.php The MIT License *
  *******************************************************************************/
 
-include("../includes/bootloader.php");
-include("includes/kernel.php");
+include('../includes/bootloader.php');
+include('includes/kernel.php');
 $api->output_headers();
 
 $gamertag = (isset($_GET['gamertag']) && !empty($_GET['gamertag'])) ? trim($_GET['gamertag']) : null;

--- a/source/2.0/games.php
+++ b/source/2.0/games.php
@@ -11,8 +11,8 @@
  * @license     http://opensource.org/licenses/mit-license.php The MIT License *
  *******************************************************************************/
 
-include("../includes/bootloader.php");
-include("includes/kernel.php");
+include('../includes/bootloader.php');
+include('includes/kernel.php');
 $api->output_headers();
 
 $gamertag = (isset($_GET['gamertag']) && !empty($_GET['gamertag'])) ? trim($_GET['gamertag']) : null;

--- a/source/2.0/includes/classes/api.class.php
+++ b/source/2.0/includes/classes/api.class.php
@@ -15,7 +15,7 @@ class API extends Base {
 	/**
 	 * Version of this API
 	 */
-	public $version = "2.0";
+	public $version = '2.0';
 
 	/**
 	 * Fetch profile information
@@ -27,39 +27,39 @@ class API extends Base {
 	 */
 	public function fetch_profile($gamertag, $region) {
 		$gamertag = trim($gamertag);
-		$url = "http://live.xbox.com/" . $region . "/Profile?gamertag=" . urlencode($gamertag);
-		$key = $this->version . ":profile." . $gamertag;
+		$url = 'http://live.xbox.com/' . $region . '/Profile?gamertag=' . urlencode($gamertag);
+		$key = $this->version . ':profile.' . $gamertag;
 		
 		$data = $this->__cache->fetch($key);
 		if(!$data) {
 			$data = $this->fetch_url($url);
-			$freshness = "new";
+			$freshness = 'new';
 			$this->__cache->store($key, $data, 180);
 		} else {
-			$freshness = "from cache";
+			$freshness = 'from cache';
 		}
 
-		if(stripos($data, "<section class=\"contextRail custom\">")) {
+		if(stripos($data, '<section class="contextRail custom">')) {
 			$user = array();
 			$user['gamertag'] = trim($gamertag);
-			$user['tier'] = (strpos($data, "<div class=\"goldBadge\">") !== false) ? "gold" : "silver";
+			$user['tier'] = (strpos($data, '<div class="goldBadge">') !== false) ? 'gold' : 'silver';
 			$user['badges']['xboxlaunchteam'] = false;
 			$user['badges']['nxelaunchteam'] = false;
 			$user['badges']['kinectlaunchteam'] = false;
-			$user['avatar']['full'] = "http://avatar.xboxlive.com/avatar/" . $gamertag . "/avatar-body.png";
-			$user['avatar']['small'] = "http://avatar.xboxlive.com/avatar/" . $gamertag . "/avatarpic-s.png";
-			$user['avatar']['large'] = "http://avatar.xboxlive.com/avatar/" . $gamertag . "/avatarpic-l.png";
-			$user['gamerscore'] = (int)trim($this->find($data, "<div class=\"gamerscore\">", "</div>"));
+			$user['avatar']['full'] = 'http://avatar.xboxlive.com/avatar/' . $gamertag . '/avatar-body.png';
+			$user['avatar']['small'] = 'http://avatar.xboxlive.com/avatar/' . $gamertag . '/avatarpic-s.png';
+			$user['avatar']['large'] = 'http://avatar.xboxlive.com/avatar/' . $gamertag . '/avatarpic-l.png';
+			$user['gamerscore'] = (int)trim($this->find($data, '<div class="gamerscore">', '</div>'));
 			$user['reputation'] = 0;
-			$user['presence'] = trim(str_replace("\r\n", " - ", trim($this->find($data, "<div class=\"presence\">", "</div>"))));
-			$user['online'] = (strpos($user['presence'], "Last seen") !== false 
+			$user['presence'] = trim(str_replace("\r\n", ' - ', trim($this->find($data, '<div class="presence">', '</div>'))));
+			$user['online'] = (strpos($user['presence'], 'Last seen') !== false 
 				or (strpos($user['presence'], 'Offline') !== false) 
 				or (trim(strpos($user['presence'], '') !== false))) ? false : true;
-			$user['gamertag'] = str_replace(array("&#39;s Profile", "'s Profile"), "", trim($this->find($data, "<h1 class=\"pageTitle\">", "</h1>")));
-			$user['motto'] = $this->clean(trim(strip_tags($this->find($data, "<div class=\"motto\">", "</div>"))));
-			$user['name'] = trim(strip_tags($this->find($data, "<div class=\"name\" title=\"", "\">")));
-			$user['location'] = trim(strip_tags(str_replace("<label>Location:</label>", "", trim($this->find($data, "<div class=\"location\">", "</div>")))));
-			$user['biography'] = trim(strip_tags(str_replace("<label>Bio:</label>", "", trim($this->find($data, "<div class=\"bio\">", "</div>")))));
+			$user['gamertag'] = str_replace(array('&#39;s Profile', '\'s Profile'), '', trim($this->find($data, '<h1 class="pageTitle">', '</h1>')));
+			$user['motto'] = $this->clean(trim(strip_tags($this->find($data, '<div class="motto">', '</div>'))));
+			$user['name'] = trim(strip_tags($this->find($data, '<div class="name" title="', '">')));
+			$user['location'] = trim(strip_tags(str_replace('<label>Location:</label>', '', trim($this->find($data, '<div class="location">', '</div>')))));
+			$user['biography'] = trim(strip_tags(str_replace('<label>Bio:</label>', '', trim($this->find($data, '<div class="bio">', '</div>')))));
 			
 			$recent_games = $this->fetch_games($gamertag, $region);
 			$user['recentactivity'] = array($recent_games['games'][0], $recent_games['games'][1], $recent_games['games'][2], $recent_games['games'][3], $recent_games['games'][4]);
@@ -88,7 +88,7 @@ class API extends Base {
 			$user['freshness'] = $freshness;
 			
 			return $user;
-		} else if(stripos($data, "errorCode: '404'")) {
+		} else if(stripos($data, 'errorCode: \'404\'')) {
 			$this->error = 501;
 			return false;
 		} else {
@@ -111,19 +111,19 @@ class API extends Base {
 	 */
 	public function fetch_achievements($gamertag, $gameid, $region) {
 		$gamertag = trim($gamertag);
-		$url = "https://live.xbox.com/" . $region . "/Activity/Details?titleId=" . urlencode($gameid) . "&compareTo=" . urlencode($gamertag);
-		$key = $this->version . ":achievements." . $gamertag . "." . $gameid;
+		$url = 'https://live.xbox.com/' . $region . '/Activity/Details?titleId=' . urlencode($gameid) . '&compareTo=' . urlencode($gamertag);
+		$key = $this->version . ':achievements.' . $gamertag . '.' . $gameid;
 		
 		$data = $this->__cache->fetch($key);
 		if(!$data) {
 			$data = $this->fetch_url($url);
-			$freshness = "new";
+			$freshness = 'new';
 			$this->__cache->store($key, $data, 600);
 		} else {
-			$freshness = "from cache";
+			$freshness = 'from cache';
 		}
 		
-		$json = $this->find($data, "broker.publish(routes.activity.details.load, ", ");");
+		$json = $this->find($data, 'broker.publish(routes.activity.details.load, ', ');');
 		$json = json_decode($json, true);
 		
 		if(!empty($json)) {
@@ -136,38 +136,38 @@ class API extends Base {
 			$achievements['achievement']['current'] = $json['Game']['Progress'][$g]['Achievements'];
 			$achievements['achievement']['total'] = $json['Game']['PossibleAchievements'];
 			$achievements['progress'] = $json['Players'][0]['PercentComplete'];
-			$achievements['lastplayed'] = (int)substr(str_replace(array("/Date(", ")/"), "", $json['Game']['Progress'][$g]['LastPlayed']), 0, 10);
+			$achievements['lastplayed'] = (int)substr(str_replace(array('/Date(', ')/'), '', $json['Game']['Progress'][$g]['LastPlayed']), 0, 10);
 			
 			$i = 0;
 			foreach($json['Achievements'] as $achievement) {
 				$achievements['achievements'][$i]['id'] = $achievement['Id'];
-				$achievements['achievements'][$i]['title'] = "";
-				$achievements['achievements'][$i]['artwork']['locked'] = $achievement['IsHidden'] ? "https://live.xbox.com/Content/Images/HiddenAchievement.png" : $achievement['TileUrl'];
-				$achievements['achievements'][$i]['artwork']['unlocked'] = "";
+				$achievements['achievements'][$i]['title'] = '';
+				$achievements['achievements'][$i]['artwork']['locked'] = $achievement['IsHidden'] ? 'https://live.xbox.com/Content/Images/HiddenAchievement.png' : $achievement['TileUrl'];
+				$achievements['achievements'][$i]['artwork']['unlocked'] = '';
 
 				if(!empty($achievement['Name'])) {
 					$achievements['achievements'][$i]['title'] = $this->clean($achievement['Name']);
 				} else {
-					$achievements['achievements'][$i]['title'] = "Secret Achievement";
+					$achievements['achievements'][$i]['title'] = 'Secret Achievement';
 				}
 
 				if(!empty($achievement['Description'])) {
 					$achievements['achievements'][$i]['description'] = $this->clean($achievement['Description']);
 				} else {
-					$achievements['achievements'][$i]['description'] = "This is a secret achievement. Unlock it to find out more.";
+					$achievements['achievements'][$i]['description'] = 'This is a secret achievement. Unlock it to find out more.';
 				}
 				
 				if(!empty($achievement['Score'])) {
 					$achievements['achievements'][$i]['gamerscore'] = $achievement['Score'];
 				} else {
-					$achievements['achievements'][$i]['gamerscore'] = "--";
+					$achievements['achievements'][$i]['gamerscore'] = 0;
 				}
 
 				$achievements['achievements'][$i]['secret'] = ($achievement['IsHidden']) ? true : false;
 				
 				if(!empty($achievement['EarnDates'][$g]['EarnedOn'])) {
 					$achievements['achievements'][$i]['unlocked'] = true;
-					$achievements['achievements'][$i]['unlockdate'] = (int)substr(str_replace(array("/Date(", ")/"), "", $achievement['EarnDates'][$g]['EarnedOn']), 0, 10);
+					$achievements['achievements'][$i]['unlockdate'] = (int)substr(str_replace(array('/Date(', ')/'), '', $achievement['EarnDates'][$g]['EarnedOn']), 0, 10);
 				} else {
 					$achievements['achievements'][$i]['unlocked'] = false;
 					$achievements['achievements'][$i]['unlockdate'] = null;
@@ -179,7 +179,7 @@ class API extends Base {
 			$achievements['freshness'] = $freshness;
 			
 			return $achievements;
-		} else if(stripos($data, "errorCode: '404'")) {
+		} else if(stripos($data, 'errorCode: \'404\'')) {
 			$this->error = 502;
 			return false;
 		} else {
@@ -201,25 +201,25 @@ class API extends Base {
 	 */
 	public function fetch_games($gamertag, $region) {
 		$gamertag = trim($gamertag);
-		$url = "https://live.xbox.com/" . $region . "/Activity?compareTo=" . urlencode($gamertag);
-		$key = $this->version . ":games." . $gamertag;
+		$url = 'https://live.xbox.com/' . $region . '/Activity?compareTo=' . urlencode($gamertag);
+		$key = $this->version . ':games.' . $gamertag;
 		
 		$data = $this->__cache->fetch($key);
 		if(!$data) {
 			$data = $this->fetch_url($url);
-			$post_data = "__RequestVerificationToken=" . urlencode(trim($this->find($data, "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"", "\" />")));
-			$headers = array("X-Requested-With: XMLHttpRequest", "Content-Type: application/x-www-form-urlencoded; charset=UTF-8");
+			$post_data = '__RequestVerificationToken=' . urlencode(trim($this->find($data, '<input name="__RequestVerificationToken" type="hidden" value="', '" />')));
+			$headers = array('X-Requested-With: XMLHttpRequest', 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8');
 			
-			$data = $this->fetch_url("https://live.xbox.com/" . $region . "/Activity/Summary?compareTo=" . urlencode($gamertag) . "&lc=1033", $url, 10, $post_data, $headers);
-			$freshness = "new";
+			$data = $this->fetch_url('https://live.xbox.com/' . $region . '/Activity/Summary?compareTo=' . urlencode($gamertag) . '&lc=1033', $url, 10, $post_data, $headers);
+			$freshness = 'new';
 			$this->__cache->store($key, $data, 600);
 		} else {
-			$freshness = "from cache";
+			$freshness = 'from cache';
 		}
 		
 		$json = json_decode($data, true);
 		
-		if($json['Success'] == "true" && $json['Data']['Players'][0]['Gamertag'] != "xboxleaders com") {
+		if($json['Success'] == 'true' && $json['Data']['Players'][0]['Gamertag'] != $this->account_gamertag) {
 			$json = $json['Data'];
 			$games = array();
 			
@@ -233,18 +233,18 @@ class API extends Base {
 			
 			$i = 0;
 			foreach($json['Games'] as $game) {
-				if($game['Progress'][$g]['LastPlayed'] !== "null") {
+				if($game['Progress'][$g]['LastPlayed'] !== 'null') {
 					$games['games'][$i]['id'] = $game['Id'];
 					$games['games'][$i]['isapp'] = ($game['PossibleScore'] == 0) ? true : false;
 					$games['games'][$i]['title'] = $this->clean($game['Name']);
-					$games['games'][$i]['artwork']['small'] = "http://download.xbox.com/content/images/66acd000-77fe-1000-9115-d802" . dechex($game['Id']) . "/1033/boxartsm.jpg";
-					$games['games'][$i]['artwork']['large'] = "http://download.xbox.com/content/images/66acd000-77fe-1000-9115-d802" . dechex($game['Id']) . "/1033/boxartlg.jpg";
+					$games['games'][$i]['artwork']['small'] = 'http://download.xbox.com/content/images/66acd000-77fe-1000-9115-d802' . dechex($game['Id']) . '/1033/boxartsm.jpg';
+					$games['games'][$i]['artwork']['large'] = 'http://download.xbox.com/content/images/66acd000-77fe-1000-9115-d802' . dechex($game['Id']) . '/1033/boxartlg.jpg';
 					$games['games'][$i]['gamerscore']['current'] = $game['Progress'][$g]['Score'];
 					$games['games'][$i]['gamerscore']['total'] = $game['PossibleScore'];
 					$games['games'][$i]['achievements']['current'] = $game['Progress'][$g]['Achievements'];
 					$games['games'][$i]['achievements']['total'] = $game['PossibleAchievements'];
 					$games['games'][$i]['progress'] = 0;
-					$games['games'][$i]['lastplayed'] = (int)substr(str_replace(array("/Date(", ")/"), "", $game['Progress'][$g]['LastPlayed']), 0, 10);
+					$games['games'][$i]['lastplayed'] = (int)substr(str_replace(array('/Date(', ')/'), '', $game['Progress'][$g]['LastPlayed']), 0, 10);
 
 					$games['gamerscore']['total'] = $games['gamerscore']['total'] + $games['games'][$i]['gamerscore']['total'];
 					$games['achievements']['current'] = $games['achievements']['current'] + $games['games'][$i]['achievements']['current'];
@@ -261,7 +261,7 @@ class API extends Base {
 			$games['freshness'] = $freshness;
 			
 			return $games;
-		} else if($json['Data']['Players'][0]['Gamertag'] == "ACCOUNT_GAMERTAG") { //!!! Change this to the scraper account's gamertag
+		} else if($json['Data']['Players'][0]['Gamertag'] == $this->account_gamertag) {
 			$this->error = 501;
 			return false;
 		} else {
@@ -283,20 +283,20 @@ class API extends Base {
 	 */
 	public function fetch_friends($gamertag, $region) {
 		$gamertag = trim($gamertag);
-		$url = "https://live.xbox.com/" . $region . "/Friends";
-		$key = $this->version . ":friends." . $gamertag;
+		$url = 'https://live.xbox.com/' . $region . '/Friends';
+		$key = $this->version . ':friends.' . $gamertag;
 
 		$data = $this->__cache->fetch($key);
 		if(!$data) {
 			$data = $this->fetch_url($url);
-			$post_data = "__RequestVerificationToken=" . urlencode(trim($this->find($data, "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"", "\" />")));
-			$headers = array("X-Requested-With: XMLHttpRequest", "Content-Type: application/x-www-form-urlencoded; charset=UTF-8");
+			$post_data = '__RequestVerificationToken=' . urlencode(trim($this->find($data, '<input name="__RequestVerificationToken" type="hidden" value="', '\' />')));
+			$headers = array('X-Requested-With: XMLHttpRequest', 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8');
 
-			$data = $this->fetch_url("https://live.xbox.com/" . $region . "/Friends/List?Gamertag=" . urlencode($gamertag), $url, 10, $post_data, $headers);
-			$freshness = "new";
+			$data = $this->fetch_url('https://live.xbox.com/' . $region . '/Friends/List?Gamertag=' . urlencode($gamertag), $url, 10, $post_data, $headers);
+			$freshness = 'new';
 			$this->__cache->store($data, 600);
 		} else {
-			$freshness = "from cache";
+			$freshness = 'from cache';
 		}
 
 		$json = json_decode($data, true);
@@ -308,13 +308,13 @@ class API extends Base {
 
 			$i = 0;
 			foreach($json['Data']['Friends'] as $friend) {
-				$friends['friends'][$i]['friend'] = $friend['GamerTag'];
+				$friends['friends'][$i]['gamertag'] = $friend['GamerTag'];
 				$friends['friends'][$i]['gamerpic']['large'] = $friend['GamerTileUrl'];
 				$friends['friends'][$i]['gamerpic']['small'] = $friend['LargeGamerTileUrl'];
 				$friends['friends'][$i]['gamerscore'] = $friend['GamerScore'];
 				$friends['friends'][$i]['online'] = $friend['IsOnline'] == 1 ? true : false;
 				$friends['friends'][$i]['status'] = $friend['Presence'];
-				$friends['friends'][$i]['lastseen'] = (int)substr(str_replace(array("/Date(", ")/"), "", $friend['LastSeen']), 0, 10);
+				$friends['friends'][$i]['lastseen'] = (int)substr(str_replace(array('/Date(', ')/'), '', $friend['LastSeen']), 0, 10);
 
 				$friends['total'] = ++$friends['total'];
 				if($friend['IsOnline']) {
@@ -347,29 +347,29 @@ class API extends Base {
 	 */
 	public function fetch_search($query, $region) {
 		$query = trim($query);
-		$url = "http://marketplace.xbox.com/" . $region . "/SiteSearch/xbox/?query=" . urlencode($query);
-		$key = $this->version . ":friends." . $query;
+		$url = 'http://marketplace.xbox.com/' . $region . '/SiteSearch/xbox/?query=' . urlencode($query);
+		$key = $this->version . ':friends.' . $query;
 
 		$data = $this->__cache->fetch($key);
 		if(!$data) {
 			$data = $this->fetch_url($url);
-			$freshness = "new";
+			$freshness = 'new';
 			$this->__cache->store($data, 6000);
 		} else {
-			$freshness = "from cache";
+			$freshness = 'from cache';
 		}
 
 		$json = json_decode($data, true);
 		if($json['totalEntries'] >= 1) {
 			$search = array();
 			$search['totalresults'] = $json['totalEntries'];
-			$search['resultslink'] = "http://marketplace.xbox.com" . $json['allResultsUrl'];
+			$search['resultslink'] = 'http://marketplace.xbox.com' . $json['allResultsUrl'];
 
 			$i = 0;
 			foreach($json['entries'] as $entry) {
 				$search['results'][$i]['title'] = $entry['title'];
 				$search['results'][$i]['parent'] = $entry['parentTitle'];
-				$search['results'][$i]['link'] = "http://marketplace.xbox.com" . $entry['detailsUrl'];
+				$search['results'][$i]['link'] = 'http://marketplace.xbox.com' . $entry['detailsUrl'];
 				$search['results'][$i]['image'] = $entry['image'];
 				$search['results'][$i]['downloadtype']['class'] = $entry['downloadTypeClass'];
 				$search['results'][$i]['downloadtype']['title'] = $entry['downloadTypeText'];

--- a/source/2.0/includes/kernel.php
+++ b/source/2.0/includes/kernel.php
@@ -11,21 +11,21 @@
  * @license     http://opensource.org/licenses/mit-license.php The MIT License *
  *******************************************************************************/
 
-include("classes/api.class.php");
+include('classes/api.class.php');
 
 $api = new API($cache);
 
-$api->format = (isset($_GET['format']) && in_array($_GET['format'], array("xml", "json"))) ? strtolower(trim($_GET['format'])) : "xml";
+$api->format = (isset($_GET['format']) && in_array($_GET['format'], array('xml', 'json'))) ? strtolower(trim($_GET['format'])) : 'xml';
 if(isset($_GET['callback']) && !empty($_GET['callback'])) {
-	$api->format = "jsonp";
+	$api->format = 'jsonp';
 }
-$api->version = "2.0";
+$api->version = '2.0';
 $api->debug = (isset($_GET['debug']));
 $api->cookie_file = COOKIE_FILE;
 $api->debug_file = DEBUG_FILE;
 $api->stack_trace_file = STACK_TRACE_FILE;
 $api->access_file = ACCESS_FILE;
-$api->save_to_access($_SERVER['REMOTE_ADDR'] . " " . $_SERVER['REQUEST_URI']);
+$api->save_to_access($_SERVER['REMOTE_ADDR'] . ' ' . $_SERVER['REQUEST_URI']);
 
 $api->init(XBOX_EMAIL, XBOX_PASSWORD);
 

--- a/source/2.0/index.php
+++ b/source/2.0/index.php
@@ -11,8 +11,8 @@
  * @license     http://opensource.org/licenses/mit-license.php The MIT License *
  *******************************************************************************/
 
-include("../includes/bootloader.php");
-include("includes/kernel.php");
+include('../includes/bootloader.php');
+include('includes/kernel.php');
 $api->output_headers();
 
 echo $api->output_error(304);

--- a/source/2.0/profile.php
+++ b/source/2.0/profile.php
@@ -11,8 +11,8 @@
  * @license     http://opensource.org/licenses/mit-license.php The MIT License *
  *******************************************************************************/
 
-include("../includes/bootloader.php");
-include("includes/kernel.php");
+include('../includes/bootloader.php');
+include('includes/kernel.php');
 $api->output_headers();
 
 $gamertag = (isset($_GET['gamertag']) && !empty($_GET['gamertag'])) ? trim($_GET['gamertag']) : null;

--- a/source/2.0/search.php
+++ b/source/2.0/search.php
@@ -11,8 +11,8 @@
  * @license     http://opensource.org/licenses/mit-license.php The MIT License *
  *******************************************************************************/
 
-include("../includes/bootloader.php");
-include("includes/kernel.php");
+include('../includes/bootloader.php');
+include('includes/kernel.php');
 $api->output_headers();
 
 $query = (isset($_GET['query']) && !empty($_GET['query'])) ? trim($_GET['query']) : null;

--- a/source/includes/bootloader.php
+++ b/source/includes/bootloader.php
@@ -11,28 +11,29 @@
  * @license     http://opensource.org/licenses/mit-license.php The MIT License *
  *******************************************************************************/
 
-include("classes/cache.class.php");
-include("classes/base.class.php");
+include('classes/cache.class.php');
+include('classes/base.class.php');
 
 /*!
  * Define the caching engine to be used.
  * Supports: apc, memcached, xcache, disk
  */
-const CACHE_ENGINE = "apc";
+const CACHE_ENGINE = 'apc';
 
 /*!
  * Define the account details.
  */
-const XBOX_EMAIL = "";
-const XBOX_PASSWORD = "";
+const XBOX_EMAIL = '';
+const XBOX_PASSWORD = '';
+const XBOX_GAMERTAG = '';
 
 /*!
  * Define some log file locations.
  */
-const COOKIE_FILE = "../includes/login_cookies.jar";
-const DEBUG_FILE = "../includes/logs/debug.log";
-const STACK_TRACE_FILE = "../includes/logs/stack_trace.log";
-const ACCESS_FILE = "../includes/logs/access.log";
+const COOKIE_FILE = '../includes/login_cookies.jar';
+const DEBUG_FILE = '../includes/logs/debug.log';
+const STACK_TRACE_FILE = '../includes/logs/stack_trace.log';
+const ACCESS_FILE = '../includes/logs/access.log';
 
 /*!
  * Initiate the caching engine.

--- a/source/includes/classes/base.class.php
+++ b/source/includes/classes/base.class.php
@@ -20,56 +20,57 @@ class Base {
 	public $redirects = 0;           // number of current redirects, prevents infinite loops
 
 	public $email, $password;        // email/password of the scraper account
+	public $account_gamertag;        // the gamertag for the scraper account
 	public $debug = false;           // debug mode flag
 	public $timeout = 8;             // number of seconds to timeout session
 
-	public $cookie_file = "";        // cookie jar path
-	public $debug_file = "";         // debug file path
-	public $stack_trace_file = "";   // stack trace file path
-	public $access_file = "";        // access log file path
+	public $cookie_file = '';        // cookie jar path
+	public $debug_file = '';         // debug file path
+	public $stack_trace_file = '';   // stack trace file path
+	public $access_file = '';        // access log file path
 
 	public $runtime = null;          // current runtime
 	public $ip = null;               // ip address to use for session, generated in __construct()
-	public $format = "xml";          // default response format
+	public $format = 'xml';          // default response format
 	public $version = null;          // current api version
 
 	/**
 	 * Error Codes
 	 */
 	public $errors = array(
-		300 => "The key supplied was not valid.",
-		301 => "The gamertag supplied was not valid.",
-		302 => "The gameid supplied was not valid.",
-		303 => "No version specified.",
-		304 => "No method specified.",
-		305 => "The region supplied is not supported by Xbox LIVE.",
-		306 => "The query supplied was not valid.",
-		500 => "There was an internal server error.",
-		501 => "The gamertag supplied does not exist on Xbox Live.",
-		502 => "The gamertag supplied has never played this game or does not exist on Xbox Live.",
-		503 => "No friends found, or friend's list is set to private.",
-		504 => "The search query returned empty.",
-		600 => "Could not login to Windows Live. Please contact me immediately.",
-		601 => "The Windows Live email address supplied was invalid.",
-		602 => "The Windows Live password supplied was invalid.",
-		603 => "Could not write to the cookie file.",
-		604 => "Could not write to the debug file.",
-		605 => "Could not write to the stack trace file.",
-		606 => "Windows Live caused an infinite redirect loop.",
-		607 => "The server timed out when trying to fetch some data.",
-		608 => "Could not write to the access file.",
-		700 => "The Xbox LIVE Service is down."
+		300 => 'The key supplied was not valid.',
+		301 => 'The gamertag supplied was not valid.',
+		302 => 'The gameid supplied was not valid.',
+		303 => 'No version specified.',
+		304 => 'No method specified.',
+		305 => 'The region supplied is not supported by Xbox LIVE.',
+		306 => 'The query supplied was not valid.',
+		500 => 'There was an internal server error.',
+		501 => 'The gamertag supplied does not exist on Xbox Live.',
+		502 => 'The gamertag supplied has never played this game or does not exist on Xbox Live.',
+		503 => 'No friends found, or friend\'s list is set to private.',
+		504 => 'The search query returned empty.',
+		600 => 'Could not login to Windows Live. Please contact me immediately.',
+		601 => 'The Windows Live email address supplied was invalid.',
+		602 => 'The Windows Live password supplied was invalid.',
+		603 => 'Could not write to the cookie file.',
+		604 => 'Could not write to the debug file.',
+		605 => 'Could not write to the stack trace file.',
+		606 => 'Windows Live caused an infinite redirect loop.',
+		607 => 'The server timed out when trying to fetch some data.',
+		608 => 'Could not write to the access file.',
+		700 => 'The Xbox LIVE Service is down.'
 	);
 
 	function __construct($cache) {
 		if($cache) $this->__cache = &$cache;
 		
 		$this->runtime = microtime(true);
-		$this->ip = rand(60, 80) . "." . rand(60, 140) . "." . rand(80, 120) . "." . rand(120, 200);
+		$this->ip = rand(60, 80) . '.' . rand(60, 140) . '.' . rand(80, 120) . '.' . rand(120, 200);
 	}
 
 	public function init($email, $password) {
-		$this->email = str_replace("@", "%40", strtolower($email));
+		$this->email = str_replace('@', '%40', strtolower($email));
 		$this->password = $password;
 
 		if($this->check_login()) {
@@ -80,36 +81,36 @@ class Base {
 	}
 
 	public function output_headers() {
-		header("Content-Type: application/" . str_replace("jsonp", "javascript", $this->format) . "; charset=utf-8");
+		header('Content-Type: application/' . str_replace('jsonp', 'javascript', $this->format) . '; charset=utf-8');
 		header('Access-Control-Allow-Origin: *');
 		header('Access-Control-Max-Age: 3628800');
-		header("Content-Type: application/" . $this->format . "; charset=utf-8");
+		header('Content-Type: application/' . $this->format . '; charset=utf-8');
 	}
 
 	public function output_payload($data) {
-		if($this->version == "1.0") {
+		if($this->version == '1.0') {
 			$payload = array(
-				"Data" => $data,
-				"In" => round(microtime(true) - $this->runtime, 3),
-				"Stat" => "ok",
-				"Authed" => "false",
-				"AuthedAs" => null
+				'Data' => $data,
+				'In' => round(microtime(true) - $this->runtime, 3),
+				'Stat' => 'ok',
+				'Authed' => 'false',
+				'AuthedAs' => null
 			);
 		} else {
 			$payload = array(
-				"status" => "success",
-				"version" => $this->version,
-				"data" => $data,
-				"runtime" => round(microtime(true) - $this->runtime, 3) 
+				'status' => 'success',
+				'version' => $this->version,
+				'data' => $data,
+				'runtime' => round(microtime(true) - $this->runtime, 3) 
 			);
 		}
 
 		switch ($this->format) {
-			case "xml":
+			case 'xml':
 				return output_pretty_xml($payload);
-			case "json":
+			case 'json':
 				return output_pretty_json($payload);
-			case "jsonp":
+			case 'jsonp':
 				return output_pretty_jsonp($payload, $_GET['callback']);
 		}
 
@@ -124,30 +125,30 @@ class Base {
 
 		if($this->version == "1.0") {
 			$payload = array(
-				"Error" => $this->errors[$code],
-				"In" => round(microtime(true) - $this->runtime, 3),
-				"Stat" => "fail",
-				"Authed" => "false",
-				"AuthedAs" => null
+				'Error' => $this->errors[$code],
+				'In' => round(microtime(true) - $this->runtime, 3),
+				'Stat' => 'fail',
+				'Authed' => 'false',
+				'AuthedAs' => null
 			);
 		} else {
 			$payload = array(
-				"status" => "error",
-				"version" => $this->version,
-				"data" => array(
-					"code" => $code,
-					"message" => $this->errors[$code]
+				'status' => 'error',
+				'version' => $this->version,
+				'data' => array(
+					'code' => $code,
+					'message' => $this->errors[$code]
 				),
-				"runtime" => round(microtime(true) - $this->runtime, 3) 
+				'runtime' => round(microtime(true) - $this->runtime, 3) 
 			);
 		}
 
 		switch ($this->format) {
-			case "xml":
+			case 'xml':
 				return output_pretty_xml($payload);
-			case "json":
+			case 'json':
 				return output_pretty_json($payload);
-			case "jsonp":
+			case 'jsonp':
 				return output_pretty_jsonp($payload, $_GET['callback']);
 		}
 
@@ -156,11 +157,11 @@ class Base {
 
 	public function save_to_access($string) {
 		if($this->debug == true) {
-			$file = fopen($this->access_file, "a+");
+			$file = fopen($this->access_file, 'a+');
 			if(!$file) {
 				$this->error = 608;
 			} else {
-				fwrite($file, "[" . date("Y-m-d H:i:s") . "] (" . $this->version . ") " . $string . "\n");
+				fwrite($file, '[' . date('Y-m-d H:i:s') . '] (' . $this->version . ') ' . $string . "\n");
 				fclose($file);
 			}
 		}
@@ -204,66 +205,66 @@ class Base {
 			$this->error = 602;
 			return false;
 		} else {
-			$this->add_cookie(".xbox.com", "MC0", time(), "/", time() + (60*60*24*365));
-			$this->add_cookie(".xbox.com", "s_vi", "[CS]v1|26AD59C185011B4D-40000113004213F1[CE]", "/", time() + (60*60*24*365));
-			$this->add_cookie(".xbox.com", "s_nr", "1297891791797", "/", time() + (60*60*24*365));
-			$this->add_cookie(".xbox.com", "s_sess", "%20s_cc%3Dtrue%3B%20s_ria%3Dflash%252011%257Csilverlight%2520not%2520detected%3B%20s_sq%3D%3B", "/", time() + (60*60*24*365));
-			$this->add_cookie(".xbox.com", "s_pers", "%20s_vnum%3D1352674046430%2526vn%253D4%7C1352674046430%3B%20s_lastvisit%3D1324587801077%7C1419195801077%3B%20s_invisit%3Dtrue%7C1324589873289%3B", "/", time() + (60*60*24*365));
-			$this->add_cookie(".xbox.com", "UtcOffsetMinutes", "60", "/", time() + (60*60*24*365));
-			$this->add_cookie(".xbox.com", "xbox_info", "t=6", "/", time() + (60*60*24*365));
-			$this->add_cookie(".xbox.com", "PersistentId", "0a652e56e40f42caac3ac84fad02ed01", "/", time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 'MC0', time(), '/', time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 's_vi', '[CS]v1|26AD59C185011B4D-40000113004213F1[CE]', '/', time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 's_nr', '1297891791797', '/', time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 's_sess', '%20s_cc%3Dtrue%3B%20s_ria%3Dflash%252011%257Csilverlight%2520not%2520detected%3B%20s_sq%3D%3B', '/', time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 's_pers', '%20s_vnum%3D1352674046430%2526vn%253D4%7C1352674046430%3B%20s_lastvisit%3D1324587801077%7C1419195801077%3B%20s_invisit%3Dtrue%7C1324589873289%3B', '/', time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 'UtcOffsetMinutes', '60', '/', time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 'xbox_info', 't=6', '/', time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 'PersistentId', '0a652e56e40f42caac3ac84fad02ed01', '/', time() + (60*60*24*365));
 
-			$url = "https://login.live.com/login.srf?wa=wsignin1.0&rpsnv=11&ct=" . time() . "&rver=6.0.5286.0&wp=MBI&wreply=https://live.xbox.com:443/xweb/live/passport/setCookies.ashx%3Frru%3Dhttp%253a%252f%252fwww.xbox.com%252fen-US%252f&flc=3d1033&lc=1033&cb=reason=0&returnUrl=http%253a%252f%252fwww.xbox.com%252fen-US%252f%253flc%253d1033&id=66262";
-			$result = $this->fetch_url($url, "http://www.xbox.com/en-US/");
+			$url = 'https://login.live.com/login.srf?wa=wsignin1.0&rpsnv=11&ct=' . time() . '&rver=6.0.5286.0&wp=MBI&wreply=https://live.xbox.com:443/xweb/live/passport/setCookies.ashx%3Frru%3Dhttp%253a%252f%252fwww.xbox.com%252fen-US%252f&flc=3d1033&lc=1033&cb=reason=0&returnUrl=http%253a%252f%252fwww.xbox.com%252fen-US%252f%253flc%253d1033&id=66262';
+			$result = $this->fetch_url($url, 'http://www.xbox.com/en-US/');
 
 			$this->stack_trace[] = array(
-				"url" => $url,
-				"postdata" => "",
-				"result" => $result
+				'url' => $url,
+				'postdata' => '',
+				'result' => $result
 			);
 
-			$this->add_cookie(".login.live.com", "WLOpt", "act=[1]", time() + (60*60*24*365));
-			$this->add_cookie(".login.live.com", "CkTst", "G" . time(), "/", time() + (60*60*24*365));
+			$this->add_cookie('.login.live.com', 'WLOpt', 'act=[1]', time() + (60*60*24*365));
+			$this->add_cookie('.login.live.com', 'CkTst', 'G' . time(), '/', time() + (60*60*24*365));
 
-			$url = $this->find($result, "urlPost:'", "',");
-			$PPFT = $this->find($result, "name=\"PPFT\" id=\"i0327\" value=\"", "\"");
-			$PPSX = $this->find($result, "srf_sRBlob='", "';");
+			$url = $this->find($result, 'urlPost:\'', '\',');
+			$PPFT = $this->find($result, 'name="PPFT" id="i0327" value="', '"');
+			$PPSX = $this->find($result, 'srf_sRBlob=\'', '\';');
 
 			//$pwd_pad = "IfYouAreReadingThisYouHaveTooMuchFreeTime";
 			//$pwd_pad = substr($pwd_pad, 0, -(strlen($this->password)));
 
-			$post_data = "login=" . $this->email . "&passwd=" . $this->password . "&KMSI=1&mest=0&type=11&LoginOptions=3&PPSX=" . $PPSX . "&PPFT=" . $PPFT . "&idsbho=1&PwdPad=&sso=&i1=1&i2=1&i3=12035&i12=1&i13=1&i14=323&i15=3762&i18=__Login_Strings%7C1%2C__Login_Core%7C1%2C";
-			$result = $this->fetch_url($url, "https://login.live.com/login.srf", null, $post_data);
+			$post_data = 'login=' . $this->email . '&passwd=' . $this->password . '&KMSI=1&mest=0&type=11&LoginOptions=3&PPSX=' . $PPSX . '&PPFT=' . $PPFT . '&idsbho=1&PwdPad=&sso=&i1=1&i2=1&i3=12035&i12=1&i13=1&i14=323&i15=3762&i18=__Login_Strings%7C1%2C__Login_Core%7C1%2C';
+			$result = $this->fetch_url($url, 'https://login.live.com/login.srf', null, $post_data);
 
 			$this->stack_trace[] = array(
-				"url" => $url,
-				"post_data" => $post_data,
-				"result" => $result
+				'url' => $url,
+				'post_data' => $post_data,
+				'result' => $result
 			);
 
-			$this->add_cookie(".live.com", "wlidperf", "throughput=3&latency=961&FR=L&ST=1297790188859", "/", time() + (60*60*24*365));
-			$this->add_cookie("login.live.com", "CkTst", time(), "/ppsecure/", time() + (60*60*24*365));
+			$this->add_cookie('.live.com', 'wlidperf', 'throughput=3&latency=961&FR=L&ST=1297790188859', '/', time() + (60*60*24*365));
+			$this->add_cookie('login.live.com', 'CkTst', time(), '/ppsecure/', time() + (60*60*24*365));
 
-			$url = $this->find($result, "id=\"fmHF\" action=\"", "\"");
-			$NAP = $this->find($result, "id=\"NAP\" value=\"", "\"");
-			$ANON = $this->find($result, "id=\"ANON\" value=\"", "\"");
-			$t = $this->find($result, "id=\"t\" value=\"", "\"");
+			$url = $this->find($result, 'id="fmHF" action="', '"');
+			$NAP = $this->find($result, 'id="NAP" value="', '"');
+			$ANON = $this->find($result, 'id="ANON" value="', '"');
+			$t = $this->find($result, 'id="t" value="', '"');
 
-			$this->add_cookie(".xbox.com", "ANON", $ANON, "/", time() + (60*60*24*365));
-			$this->add_cookie(".xbox.com", "NAP", $NAP, "/", time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 'ANON', $ANON, '/', time() + (60*60*24*365));
+			$this->add_cookie('.xbox.com', 'NAP', $NAP, '/', time() + (60*60*24*365));
 
-			$post_data = "NAPExp=" . date("c", mktime(date("H"), date("i"), date("s"), date("n") + 1)) . "&NAP=" . $NAP . "&ANONExp=" . date("c", mktime(date("H"), date("i"), date("s"), date("n") + 1)) . "&ANON=" . $ANON . "&t=" . $t;
-			$result = $this->fetch_url($url, "", 16, $post_data);
+			$post_data = 'NAPExp=' . date('c', mktime(date('H'), date('i'), date('s'), date('n') + 1)) . '&NAP=' . $NAP . '&ANONExp=' . date('c', mktime(date('H'), date('i'), date('s'), date('n') + 1)) . '&ANON=' . $ANON . '&t=' . $t;
+			$result = $this->fetch_url($url, '', 16, $post_data);
 
 			$this->stack_trace[] = array(
-				"url" => $url,
-				"post_data" => $post_data,
-				"result" => $result
+				'url' => $url,
+				'post_data' => $post_data,
+				'result' => $result
 			);
 
-			$result = $this->fetch_url("http://www.xbox.com/en-US/");
+			$result = $this->fetch_url('http://www.xbox.com/en-US/');
 
-			if(stripos($result, "currentUser.isSignedIn = true") !== false) {
+			if(stripos($result, 'currentUser.isSignedIn = true') !== false) {
 				$this->logged_in = true;
 
 				return true;
@@ -335,8 +336,8 @@ class Base {
 		}
 
 		$ip = array(
-			"REMOTE_ADDR: " . $this->ip, 
-			"HTTP_X_FORWARDED_FOR: " . $this->ip
+			'REMOTE_ADDR: ' . $this->ip, 
+			'HTTP_X_FORWARDED_FOR: ' . $this->ip
 		);
 
 		if($headers) {
@@ -349,7 +350,7 @@ class Base {
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-		curl_setopt($ch, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.6) Gecko/20070725 Firefox/2.0.0.6");
+		curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.6) Gecko/20070725 Firefox/2.0.0.6');
 		curl_setopt($ch, CURLOPT_TIMEOUT, ($timeout) ? $timeout : $this->timeout);
 		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -369,17 +370,17 @@ class Base {
 
 		$result = curl_exec($ch);
 
-		if(stripos($result, "<title>Object moved</title>") !== false) {
-			$follow = urldecode(trim($this->find($result, "<a href=\"", "\">")));
+		if(stripos($result, '<title>Object moved</title>') !== false) {
+			$follow = urldecode(trim($this->find($result, '<a href="', '">')));
 
-			if(substr($follow, 0, 1) == "/") {
+			if(substr($follow, 0, 1) == '/') {
 				$this->redirects++;
-				$result = $this->fetch_url("http://live.xbox.com" . $follow, $url);
+				$result = $this->fetch_url('http://live.xbox.com' . $follow, $url);
 			} else {
 				$this->redirects++;
 				$result = $this->fetch_url($follow, $url);
 			}
-		} else if(stripos($result, "<!-------Error Info") !== false) {
+		} else if(stripos($result, '<!-------Error Info') !== false) {
 			$this->force_new_login();
 
 			if($this->logged_in) {
@@ -389,15 +390,15 @@ class Base {
 				$this->error = 600;
 				return false;
 			}
-		} else if(stripos($result, "UserAcceptsNewTermsOfUse") !== false) {
-			$follow = "https://live.xbox.com" . $this->find($result, "<form action=\"", "\" method=\"post\">");
-			$token = $this->find($result, "<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"", "\" />");
-			$post = "UserAcceptsNewTermsOfUse=true&__RequestVerificationToken=" . urlencode($token);
+		} else if(stripos($result, 'UserAcceptsNewTermsOfUse') !== false) {
+			$follow = 'https://live.xbox.com' . $this->find($result, '<form action="', '" method="post">');
+			$token = $this->find($result, '<input name="__RequestVerificationToken" type="hidden" value="', '" />');
+			$post = 'UserAcceptsNewTermsOfUse=true&__RequestVerificationToken=' . urlencode($token);
 
 			$result = $this->fetch_url($follow, $url, null, $post);
 			$result = $this->fetch_url($url, $referer, $timeout, $post_data, $headers);
 		} else {
-			$this->save_to_debug("Loaded URL: " . $url);
+			$this->save_to_debug('Loaded URL: ' . $url);
 		}
 
 		if(!$result) {
@@ -433,11 +434,11 @@ class Base {
 	}
 
 	protected function clean($string) {
-		$string = html_entity_decode($string, ENT_QUOTES, "UTF-8");
-		$string = htmlentities($string, ENT_QUOTES, "UTF-8");
+		$string = html_entity_decode($string, ENT_QUOTES, 'UTF-8');
+		$string = htmlentities($string, ENT_QUOTES, 'UTF-8');
 
-		if(function_exists("mb_convert_encoding")) {
-			$string = mb_convert_encoding($string, "UTF-8");
+		if(function_exists('mb_convert_encoding')) {
+			$string = mb_convert_encoding($string, 'UTF-8');
 		} else {
 			$string = utf8_decode($string);
 		}
@@ -445,12 +446,12 @@ class Base {
 		return $string;
 	}
 
-	protected function add_cookie($domain, $name, $value, $path = "/", $expires = 0) {
-		$file = fopen($this->cookie_file, "a");
+	protected function add_cookie($domain, $name, $value, $path = '/', $expires = 0) {
+		$file = fopen($this->cookie_file, 'a');
 		if(!$file) {
 			$this->error = 603;
 		} else {
-			fwrite($file, $domain . "	TRUE	" . $path . "	FALSE	" . $expires . "	" . $name . "	" . $value . "\r\n");
+			fwrite($file, $domain . '	TRUE	' . $path . '	FALSE	' . $expires . '	' . $name . '	' . $value . "\r\n");
 			fclose($file);
 		}
 	}
@@ -459,18 +460,18 @@ class Base {
 		$this->logged_in = false;
 
 		if(file_exists($this->cookie_file)) {
-			$f = fopen($this->cookie_file, "w");
+			$f = fopen($this->cookie_file, 'w');
 			fclose($f);
 		}
 	}
 
 	protected function save_to_debug($string) {
 		if($this->debug == true) {
-			$file = fopen($this->debug_file, "a+");
+			$file = fopen($this->debug_file, 'a+');
 			if(!$file) {
 				$this->error = 604;
 			} else {
-				fwrite($file, "[" . date("Y-m-d H:i:s") . "] (" . $this->version . ") " . $string . "\n");
+				fwrite($file, '[' . date('Y-m-d H:i:s') . '] (' . $this->version . ') ' . $string . "\n");
 				fclose($file);
 			}
 		}
@@ -478,7 +479,7 @@ class Base {
 
 	protected function save_stack_trace() {
 		if($this->debug == true) {
-			$file = fopen($this->stack_trace_file, "w");
+			$file = fopen($this->stack_trace_file, 'w');
 			if(!$file) {
 				$this->error = 605;
 			} else {
@@ -502,7 +503,7 @@ function output_pretty_json($json) {
  * Not pretty, but it works. Outputs JSONP callback function.
  */
 function output_pretty_jsonp($json, $callback) {
-	return $callback . "(" . json_encode($json, JSON_PRETTY_PRINT) . ");";
+	return $callback . '(' . json_encode($json, JSON_PRETTY_PRINT) . ');';
 }
 
 /*!
@@ -510,12 +511,12 @@ function output_pretty_jsonp($json, $callback) {
  */
 function output_pretty_xml($mixed, $xml = false) {
 	if($xml === false) {
-		$xml = new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?><xbox status=\"" . $mixed['status'] . "\" version=\"" . $mixed['version'] . "\" />");
+		$xml = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><xbox status="' . $mixed['status'] . '" version="' . $mixed['version'] . '" />');
 	}
 
 	foreach($mixed as $key => $value) {
 		if(is_numeric($key)) {
-			$key = rtrim($xml->getName(), "s");
+			$key = rtrim($xml->getName(), 's');
 		}
 
 		if(is_array($value)) {

--- a/source/includes/classes/cache.class.php
+++ b/source/includes/classes/cache.class.php
@@ -12,8 +12,8 @@
  *******************************************************************************/
 
 class Cache {
-    public $driver = "disk";
-    public $root = "/tmp/";
+    public $driver = 'disk';
+    public $root = '/tmp/';
     
     public $hits = 0;
     public $misses = 0;
@@ -25,19 +25,19 @@ class Cache {
         if($driver) $this->driver = strtolower($driver);
         if($root) $this->root = $root;
         
-        if($this->driver == "apc") {
-            if(!function_exists("apc_fetch")) $this->driver = "disk";
-        } else if($this->driver == "memcached") {
-            if(!class_exists("Memcached")) $this->driver = "disk";
-        } else if($this->driver == "xcache") {
-            if(!function_exists("xcache_get")) $this->driver = "disk";
+        if($this->driver == 'apc') {
+            if(!function_exists('apc_fetch')) $this->driver = 'disk';
+        } else if($this->driver == 'memcached') {
+            if(!class_exists('Memcached')) $this->driver = 'disk';
+        } else if($this->driver == 'xcache') {
+            if(!function_exists('xcache_get')) $this->driver = 'disk';
         }
         
-        if($this->driver == "memcached") {
+        if($this->driver == 'memcached') {
             $this->__memcached = new Memcached();
-            $this->__memcached->addServer("localhost", 11211);
-        } else if($this->driver == "disk") {
-            $file = $this->root . "c_index";
+            $this->__memcached->addServer('localhost', 11211);
+        } else if($this->driver == 'disk') {
+            $file = $this->root . 'c_index';
             
             if(!file_exists($file)) {
                 $this->save_index();
@@ -48,8 +48,8 @@ class Cache {
             $handle = opendir($this->root);
             if($handle) {
                 while(false !== ($file = readdir($handle))) {
-                    if(substr($file, 0, 2) == "c_") {
-                        $key = str_replace(array("c_", ".cache"), "", $file);
+                    if(substr($file, 0, 2) == 'c_') {
+                        $key = str_replace(array('c_', '.cache'), '', $file);
                         $created = filemtime($this->root . $file);
                         $ttl = (int)$this->index[$key]['ttl'];
                         $expires = $created + $ttl;
@@ -68,13 +68,13 @@ class Cache {
     }
     
     public function fetch($key) {
-        if($this->driver == "apc") {
+        if($this->driver == 'apc') {
             $data = apc_fetch($key);
-        } else if($this->driver == "xcache") {
+        } else if($this->driver == 'xcache') {
             $data = xcache_get($key);
-        } else if($this->driver == "memcached") {
+        } else if($this->driver == 'memcached') {
             $data = $this->__memcached->get($key);
-        } else if($this->driver == "disk") {
+        } else if($this->driver == 'disk') {
             $file = $this->get_filename($key);
             if(file_exists($file)) {
                 $data = file_get_contents($file);
@@ -95,25 +95,25 @@ class Cache {
     public function store($key, $data, $ttl = 0) {
         $data = serialize($data);
         
-        if($this->driver == "apc") {
+        if($this->driver == 'apc') {
             return apc_store($key, $data, $ttl);
-        } else if($this->driver == "memcached") {
+        } else if($this->driver == 'memcached') {
             return $this->__memcached->set($key, $data, $ttl);
-        } else if($this->driver == "xcache") {
+        } else if($this->driver == 'xcache') {
             return xcache_set($key, $data, $ttl);
-        } else if($this->driver == "disk") {
+        } else if($this->driver == 'disk') {
             $file = $this->get_filename($key);
             
             if(file_exists($file)) {
                 unlink($file);
             }
             
-            $handle = fopen($file, "w");
+            $handle = fopen($file, 'w');
             fwrite($handle, $data);
             fclose($handle);
             
             $this->index[$key] = array(
-                "ttl" => $ttl
+                'ttl' => $ttl
             );
             
             $this->save_index();
@@ -123,13 +123,13 @@ class Cache {
     }
     
     public function remove($key) {
-        if($this->driver == "apc") {
+        if($this->driver == 'apc') {
             return apc_delete($key);
-        } else if($this->driver == "memcached") {
+        } else if($this->driver == 'memcached') {
             return $this->__memcached->delete($key);
-        } else if($this->driver == "xcache") {
+        } else if($this->driver == 'xcache') {
             return xcache_unset($key);
-        } else if($this->driver == "disk") {
+        } else if($this->driver == 'disk') {
             $file = $this->get_filename($key);
             
             if(file_exists($file)) {
@@ -144,15 +144,15 @@ class Cache {
     }
     
     protected function save_index() {
-        $file = $this->root . "c_index";
+        $file = $this->root . 'c_index';
         
-        $handle = fopen($file, "w");
+        $handle = fopen($file, 'w');
         fwrite($handle, serialize($this->index));
         fclose($handle);
     }
     
     protected function get_filename($key) {
-        return $this->root . "c_" . $key . ".cache";
+        return $this->root . 'c_' . $key . '.cache';
     }
 }
 


### PR DESCRIPTION
Decided to make the source code formatting consistent, using single quotes instead of double for all strings. Also added a new variable, `account_gamertag`, which will be used to filter out results from the scraper account in the `friends` and `achievements` endpoints.

Lastly, I updated the readme to show how the workflow will be organized.
