### PR TITLE
Colored Achievements Fix

### DIFF
--- a/source/2.0/includes/classes/api.class.php
+++ b/source/2.0/includes/classes/api.class.php
@@ -149,7 +149,7 @@ class API extends Base {
 				if(empty($coloredtile[0])) {
 					$achievements['achievements'][$i]['artwork']['unlocked'] = '';
 				} else {
-					$achievements['achievements'][$i]['artwork']['unlocked'] = 'https://image-ssl.xboxlive.com/global/t.' . dechex($json['Game']['Id']) . $coloredtile[0] . '/';
+					$achievements['achievements'][$i]['artwork']['unlocked'] = 'https://image-ssl.xboxlive.com/global/t.' . dechex($json['Game']['Id']) . $coloredtile[0];
 				}
 
 				if(!empty($achievement['Name'])) {


### PR DESCRIPTION
It's still hit or miss, especially with certain tile URLs that aren't proper base64, but for all intents and purposes, it works. It's definitely something to improve upon.
